### PR TITLE
Add functionality to read encrypted data from file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Binary
 k8s-etcd-decryptor
+secretvalue

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ ./k8s-etcd-decryptor
 
 To decrypt a certain object from a Kubernetes etcd, proceed as follows:
 
-1) To extract the an object from `etcd`, use the following command inside the `etcd` container to set up the environment variables (often found in /etc/etcd/etcd.conf) and retrieve the base64-encoded `etcd` object (a `Secret` in this example):
+1) To extract the an object from `etcd`, use the following command inside the `etcd` container to set up the environment variables (often found in /etc/etcd/etcd.conf) and retrieve the base64-encoded `etcd` object using `etcdctl` (a `Secret` in this example):
 
    ```
    # source /etc/etcd/etcd.conf 
@@ -36,7 +36,7 @@ To decrypt a certain object from a Kubernetes etcd, proceed as follows:
    {"header":{"cluster_id":1535328224928523406,"member_id":10396734553733729853,"revision":30198,"raft_term":3},"kvs":[{"key":"L2t1YmVybmV0ZXMuaW8vc2VjcmV0cy9zaW1vbi1wcm9qZWN0L215LXNlY3JldA==","create_revision":28525,"mod_revision":28525,"version":1,"value":"azhzOmVuYzphZXNjYmM6djE6c2ltb246lvj7pYRT71cyo+aqLPjJ2kuvAOI4FghpUG5n405KRZOLnDU3EAw55jxDt+qAJPFArX7Jmp8wppRgdk7NE+3XiOCGnQBQWGkJX1irZ31DxotG4CfrxH4pJ0Agnmzw/e+bJAJGPO84SMFjrhInd14iseyErrfrG5s/dy0tEyDUtQMrVGMLkztYoELfBARK8+PP3H52oJmlM1rvU6jV09dbcQ=="}],"count":1}
    ```
 
-2) Retrieve the base64-encoded "secret" from the `EncryptionConfig` in /etc/origin/master/encryption-config.yaml from your Master Nodes:
+2) Retrieve the base64-encoded encryption key ("secret") from the `EncryptionConfig` (OpenShift stores it in `/etc/origin/master/encryption-config.yaml` or `/etc/kubernetes/manifests/kube-apiserver-pod-<N>/secrets/encryption-config/encryption-config`) from your Control Plane Nodes:
 
    ```
    # cat /etc/origin/master/encryption-config.yaml 
@@ -70,4 +70,4 @@ simon-project"*$6567b48b-9f45-11ea-8fb6-fa163e827b272z
 mysupersecretOpaque"
 ```
 
-This will show the object (a `Secret` in this case) as a string, which is not very nice but works well for most use-cases.
+This will print the the object (a `Secret` in this case) data as a string, which is not very nice but works well for most use-cases.

--- a/decryptor.go
+++ b/decryptor.go
@@ -31,10 +31,11 @@ func main() {
 
 	// Decoded string looks like this: "k8s:enc:aescbc:v1:<provider-name>:<binary-aes-encrypted-data>"
 	// "<binary-aes-encrypted-data>" := "<32-bit IV><rest-of-data>"
-	s := strings.Split(string(v), ":")
+	s := strings.SplitN(string(v), ":", 6)
 
 	if len(s) != 6 {
 		fmt.Printf("Value does not have the right format: %v", s)
+		fmt.Println("Length of array is", len(s))
 		os.Exit(1)
 	}
 	if s[2] != "aescbc" {


### PR DESCRIPTION
This PR adds the functionality that the encrypted data from etcd can be read from a file.

In practice we have seen that the tool can fail with the following error message when a very large object (for example a large `Secret`) is pasted as the input:

```
Failed to decode etcd value: illegal base64 data at input byte 4093
```

It turns out that this is due to the terminal input buffer size limit, which is 4096 bytes on
GNU/Linux (look for N_TTY_BUF_SIZE in the kernel sources): https://groups.google.com/g/golang-nuts/c/ndh-1wdsWYs/m/Watbhx8JAwAJ

When such a case is detected, then a message is printed and the user should put his values in a file called `secretvalue`. The program will then read from that file if it is present and skip asking for the encrypted data.

The PR also updates the README with the current location of the EncryptionConfig in newer OCP versions.